### PR TITLE
Avoid Double Install of activescaffold/active_scaffold and vhochstein/active_scaffold_vho

### DIFF
--- a/active_scaffold_batch_vho.gemspec
+++ b/active_scaffold_batch_vho.gemspec
@@ -70,20 +70,20 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<active_scaffold_vho>, ["> 3.0.13"])
+      s.add_runtime_dependency(%q<active_scaffold>, ["> 3.0.13"])
     else
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_dependency(%q<rcov>, [">= 0"])
-      s.add_dependency(%q<active_scaffold_vho>, ["> 3.0.13"])
+      s.add_dependency(%q<active_scaffold>, ["> 3.0.13"])
     end
   else
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
     s.add_dependency(%q<rcov>, [">= 0"])
-    s.add_dependency(%q<active_scaffold_vho>, ["> 3.0.13"])
+    s.add_dependency(%q<active_scaffold>, ["> 3.0.13"])
   end
 end
 


### PR DESCRIPTION
When trying to use both of activescaffold/active_scaffold, branch 3.0 and active_scaffold_batch_vho, respectively, bundler double installs as and as_vho due to the gemspec of as_batch. This is only a naive patch, but it might even be enough.

Regards
Michael
